### PR TITLE
fix: resolve pip package conflict

### DIFF
--- a/server-driven/server/python/requirements.txt
+++ b/server-driven/server/python/requirements.txt
@@ -1,16 +1,5 @@
-certifi==2023.7.22
-charset-normalizer==3.2.0
-click==8.1.3
 Flask==2.2.2
-idna==3.4
-itsdangerous==2.1.2
-Jinja2==3.1.2
-MarkupSafe==2.1.1
-pycodestyle==2.9.1
-pyflakes==2.5.0
 python-dotenv==1.0.0
-requests==2.28.1
 stripe==4.1.0
-urllib3==2.0.4
+requests==2.31.0
 Werkzeug==2.2.2
-yapf==0.32.0


### PR DESCRIPTION
When we tried to run the Python example, we encountered the following error on the `pip install -r requirements.txt` step:

```bash
$ pip install

ERROR: Cannot install -r requirements.txt (line 11) and urllib3==2.0.4 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested urllib3==2.0.4
    requests 2.28.1 depends on urllib3<1.27 and >=1.21.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

## What we did
It looks like there was a version conflict, so I resolved it by updating the requirements.txt file.

After updating this file, the application started successfully without any issues, as demonstrated in the following screenshots:

<img width="987" alt="スクリーンショット 2024-10-24 10 50 19" src="https://github.com/user-attachments/assets/9ea78fbc-804f-4c64-b859-d2660183afb7">
<img width="526" alt="スクリーンショット 2024-10-24 10 50 24" src="https://github.com/user-attachments/assets/ceddaca5-f992-45b5-bfc9-da942c39b56f">


## Steps to test
Please follow the instructions in the [README.md](https://github.com/stripe-samples/terminal/blob/fix/pip-conflict/server-driven/server/python/README.md) file.